### PR TITLE
fix tensor_packbits_cuda_kernel for when batch size is not a multiple of bit count

### DIFF
--- a/difflogic/cuda/difflogic_kernel.cu
+++ b/difflogic/cuda/difflogic_kernel.cu
@@ -557,7 +557,7 @@ __global__ void tensor_packbits_cuda_kernel(
     ) {
         for (  // batch in b
             auto col = blockIdx.x * blockDim.x + threadIdx.x;
-            col < t.size(1);
+            col < b.size(1);
             col += blockDim.x * gridDim.x
         ) {
 
@@ -569,8 +569,11 @@ __global__ void tensor_packbits_cuda_kernel(
             constexpr int bit_count = std::numeric_limits<unsigned_scalar_t>::digits;
             val.signed_scalar = b[row][col];
             for (unsigned int i = 0; i < bit_count; ++i) {
-                const unsigned_scalar_t bit_mask = static_cast<unsigned_scalar_t>(t[row][bit_count * col + i]) << i;
-                val.unsigned_scalar = val.unsigned_scalar | bit_mask;
+                const auto t_col = bit_count * col + i;
+                if (t_col < t.size(1)) {    
+                    const unsigned_scalar_t bit_mask = static_cast<unsigned_scalar_t>(t[row][t_col]) << i;
+                    val.unsigned_scalar = val.unsigned_scalar | bit_mask;
+                }
             }
             b[row][col] = val.signed_scalar;
         }

--- a/difflogic/packbitstensor.py
+++ b/difflogic/packbitstensor.py
@@ -1,5 +1,6 @@
 import difflogic_cuda
 import torch
+import numpy as np
 
 
 class PackBitsTensor:
@@ -26,3 +27,15 @@ class PackBitsTensor:
         Arguments are ignored.
         """
         return self
+
+    def _get_member_repr(self, member):
+        if len(member) <= 4:
+            result = [(np.binary_repr(integer, width=self.bit_count))[::-1] for integer in member]
+            return ' '.join(result)
+        first_three = [(np.binary_repr(integer, width=self.bit_count))[::-1] for integer in member[:3]]
+        sep = "..."
+        final = np.binary_repr(member[-1], width=self.bit_count)[::-1]
+        return f"{' '.join(first_three)} {sep} {final}"
+    
+    def __repr__(self):
+        return '\n'.join([self._get_member_repr(item) for item in self.t])


### PR DESCRIPTION
Fixed [this](https://github.com/Felix-Petersen/difflogic/issues/16) issue.

The new kernel also makes sure that padding bits are all zeros. Although I think this isn't necessary for correct operation.

Also added `__repr__ ` to `PackBitsTensor` which helps detect the problem or the lack of it and is also generally useful.