### PR TITLE
Make CUDA extensions optional

### DIFF
--- a/INSTALLATION_SUPPORT.md
+++ b/INSTALLATION_SUPPORT.md
@@ -5,7 +5,7 @@ The library can be installed with:
 ```shell
 pip install difflogic
 ```
-> ⚠️ Note that `difflogic` requires CUDA, the CUDA Toolkit (for compilation), and `torch>=1.9.0` (matching the CUDA version).
+> ⚠️ Note that, by default, `difflogic` requires CUDA, the CUDA Toolkit (for compilation), and `torch>=1.9.0` (matching the CUDA version). CUDA can be disable by setting a flag like so `export DIFFLOGIC_BUILD_CUDA_EXT=false` before running `pip install .` Only the much slower pure python implementation is available in that case.
 
 **It is very important that the installed version of PyTorch was compiled with a CUDA version that is compatible with the CUDA version of the locally installed CUDA Toolkit.**
 

--- a/difflogic/difflogic.py
+++ b/difflogic/difflogic.py
@@ -99,9 +99,7 @@ class LogicLayer(torch.nn.Module):
         assert x.shape[-1] == self.in_dim, (x[0].shape[-1], self.in_dim)
 
         if self.indices[0].dtype == torch.int64 or self.indices[1].dtype == torch.int64:
-            print(self.indices[0].dtype, self.indices[1].dtype)
             self.indices = self.indices[0].long(), self.indices[1].long()
-            print(self.indices[0].dtype, self.indices[1].dtype)
 
         a, b = x[..., self.indices[0]], x[..., self.indices[1]]
         if self.training:

--- a/difflogic/difflogic.py
+++ b/difflogic/difflogic.py
@@ -7,7 +7,7 @@ from .packbitstensor import PackBitsTensor
 try:
     import difflogic_cuda
 except ImportError:
-    warnings.warn('failed to import difflogic_cuda. no cuda features will be available')
+    warnings.warn('failed to import difflogic_cuda. no cuda features will be available', ImportWarning)
 
 ########################################################################################################################
 

--- a/difflogic/difflogic.py
+++ b/difflogic/difflogic.py
@@ -1,9 +1,13 @@
+import warnings
 import torch
-import difflogic_cuda
 import numpy as np
 from .functional import bin_op_s, get_unique_connections, GradFactor
 from .packbitstensor import PackBitsTensor
 
+try:
+    import difflogic_cuda
+except ImportError:
+    warnings.warn('failed to import difflogic_cuda. no cuda features will be available')
 
 ########################################################################################################################
 

--- a/difflogic/packbitstensor.py
+++ b/difflogic/packbitstensor.py
@@ -1,6 +1,11 @@
-import difflogic_cuda
+import warnings
 import torch
 import numpy as np
+
+try:
+    import difflogic_cuda
+except ImportError:
+    warnings.warn('failed to import difflogic_cuda. no cuda features will be available')
 
 
 class PackBitsTensor:

--- a/difflogic/packbitstensor.py
+++ b/difflogic/packbitstensor.py
@@ -5,7 +5,7 @@ import numpy as np
 try:
     import difflogic_cuda
 except ImportError:
-    warnings.warn('failed to import difflogic_cuda. no cuda features will be available')
+    warnings.warn('failed to import difflogic_cuda. no cuda features will be available', ImportWarning)
 
 
 class PackBitsTensor:


### PR DESCRIPTION
Hello everyone,
this PR makes the compilation of the CUDA extensions optional and allows to use the pure python implementation without installing cuda. I made the following changes:
- adapt setup.py so that building the extension difflogic_cuda is optional (still built by default)
- introduce the env variable DIFFLOGIC_BUILD_CUDA_EXT (set to false to disable extension) and update installation instructions accordingly
- wrap all imports of difflogic_cuda in try-except statements that throw an import warning if the CUDA extension was not installed
- In experiments/main.py, use the argument args.implementation to control what implementation to use (already existed, but was not actually used)
