### PR TITLE
Update difflogic_kernel.cu

### DIFF
--- a/difflogic/cuda/difflogic_kernel.cu
+++ b/difflogic/cuda/difflogic_kernel.cu
@@ -647,14 +647,14 @@ __global__ void groupbitsum_kernel(
 
             typedef typename std::make_unsigned<scalar_t>::type unsigned_scalar_t;
             union scalar_t_ {
-                unsigned_scalar_t unsigned_scalar;
                 scalar_t signed_scalar;
+                unsigned_scalar_t unsigned_scalar;
             };
             constexpr int bit_count = std::numeric_limits<unsigned_scalar_t>::digits;
             int res = 0;
             const auto class_size = b.size(0) / t.size(0);
             for (int i = 0; i < class_size; ++i) {
-                const scalar_t_ val = {.signed_scalar = b[row * class_size + i][col / bit_count]};
+                const union scalar_t_ val = {.signed_scalar = b[row * class_size + i][col / bit_count]};
                 const unsigned_scalar_t bit_mask = static_cast<unsigned_scalar_t>(1) << static_cast<uint32_t>(col % bit_count);
                 res += !!(val.unsigned_scalar & bit_mask);
             }


### PR DESCRIPTION
Hi, when i compile difflogic, it failed here.
error: expected an expression
                  const union scalar_t_ val = {.signed_scalar = b[row * class_size + i][col / bit_count]};
                                               ^
this error, i don't understand why compiler can't init 2nd variable of the union scalar_t_, so i switch them and then it worked.